### PR TITLE
Remove Long Time Offline IPFS Gateway

### DIFF
--- a/ipfs-domains.txt
+++ b/ipfs-domains.txt
@@ -95,7 +95,6 @@ ipfs.moonicorn.network
 ipfs.mrh.io
 ipfs.mttk.net
 ipfs.namebase.io
-ipfs.netw0rk.io
 ipfs.oceanprotocol.com
 ipfs.overpi.com
 ipfs.oxerr.net


### PR DESCRIPTION
My gateway is offline for a long time now. I receive a lot of DNS requests though and try to get rid of any listings